### PR TITLE
Fix documentation issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -8,16 +8,16 @@ body:
     attributes:
       value: Thanks for taking the time to fill out this report!
 
-  - type: radio
+  - type: dropdown
     id: problem-type
     attributes:
       label: Problem/request type
       description: What are you trying to get fixed or added?
       options:
-        - label: typo
-        - label: example request
-        - label: broken link
-        - label: other
+        - typo
+        - example request
+        - broken link
+        - other
     validations:
       required: true
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,5 +19,6 @@ Please add a line in the relevant section of [CHANGELOG.md](https://github.com/R
 The optional `-- format` and `-- write` arguments (see above) attempt to correct formatting issues prior to running the linter, and spelling mistakes prior to running the spellcheck, respectively. You can also run all of the above checks using `$ nox -s pre-commit` instead of running them individually.
 
 ## Further checks:
-- [ ] Code is commented, particularly in hard-to-understand areas
-- [ ] Tests are added that prove fix is effective or that feature works
+- [ ] The documentation builds: `$ nox -s docs`.
+- [ ] Code is commented, particularly in hard-to-understand areas.
+- [ ] Tests are added that prove fix is effective or that feature works.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,17 +4,23 @@ on:
   push:
     paths-ignore:
       - '*.md'
+      - '*.txt'
       - 'README*'
-      - 'LICENSE*'
+      - 'CHANGELOG*'
+      - 'docs/*'
       - 'images/*'
+      - '.github/ISSUE_TEMPLATE/*'
 
   pull_request:
     branches: [main]
     paths-ignore:
       - '*.md'
+      - '*.txt'
       - 'README*'
-      - 'LICENSE*'
+      - 'CHANGELOG*'
+      - 'docs/*'
       - 'images/*'
+      - '.github/ISSUE_TEMPLATE/*'
 
 jobs:
   lint:


### PR DESCRIPTION
# Description
Documentation issues template referred to bad "radio" type. Also, made adjustments to ci.yml so modifying certain files don't trigger build-and-test workflow.

## Type of change
Please add a line in the relevant section of [CHANGELOG.md](https://github.com/ROVI-org/thevenin/blob/main/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (back-end change that improves speed/readability/etc.)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`
- [x] Badges are updated: `$ nox -s badges`

The optional `-- format` and `-- write` arguments (see above) attempt to correct formatting issues prior to running the linter, and spelling mistakes prior to running the spellcheck, respectively. You can also run all of the above checks using `$ nox -s pre-commit` instead of running them individually.

## Further checks:
- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests are added that prove fix is effective or that feature works
