### PR TITLE
Change exp to demand, fix README example

### DIFF
--- a/.github/linters/.codespellrc
+++ b/.github/linters/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = build,docs,images,reports,sphinx
+skip = build,docs,images,reports,sphinx,references
 ignore-words-list = thev

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-# Local developer tools
-dev.bat
+# OSX
+.DS_Store
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -7,11 +7,15 @@ __pycache__/
 *$py.class
 
 # C extensions
+*.c
 *.so
+*.pyd
+*.pxi
+
+# VSCode
+.vscode/
 
 # Distribution / packaging
-docs/
-sphinx/
 .Python
 build/
 develop-eggs/
@@ -25,11 +29,11 @@ parts/
 sdist/
 var/
 wheels/
+wheelhouse/
 share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg
-MANIFEST
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -42,6 +46,7 @@ pip-log.txt
 pip-delete-this-directory.txt
 
 # Unit test / coverage reports
+references/
 reports/
 htmlcov/
 .tox/
@@ -74,6 +79,10 @@ instance/
 
 # Scrapy stuff:
 .scrapy
+
+# Sphinx documentation
+docs/
+sphinx/
 
 # PyBuilder
 .pybuilder/
@@ -112,6 +121,8 @@ ipython_config.py
 #   in version control.
 #   https://pdm.fming.dev/#use-with-ide
 .pdm.toml
+.pdm-python
+.pdm-build/
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/
@@ -135,9 +146,6 @@ venv.bak/
 # Spyder project settings
 .spyderproject
 .spyproject
-
-# VSCode 
-.vscode
 
 # Rope project settings
 .ropeproject

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ We recommend using [Anaconda](https://anaconda.com) to install this package due 
 
 After cloning the repository, or downloading the files, use your terminal (MacOS/Linux) or Anaconda Prompt (Windows) to navigate into the folder with the `pyproject.toml` file. Once in the correct folder, execute the following commands:
 
-```console
+```
 conda create -n rovi python=3.12 scikits_odes_sundials -c conda-forge
 conda activate rovi
 pip install .
@@ -74,7 +74,7 @@ The first command will create a new Python environment named `rovi`. The environ
 
 If you plan to make changes to the package, you may also want to consider installing in "editable" mode using the `-e` flag, and including the optional developer dependencies, using `[dev]`, as shown below. If you plan to push any changes back into this repository, you should see the [contributing](#contributing) section first.
 
-```console
+```
 pip install -e .[dev]
 ```
 
@@ -86,11 +86,11 @@ import thevenin
 
 model = thevenin.Model()
 
-exp = thevenin.Experiment()
-exp.add_step('current_A', 15., (3600., 1.), limits=('voltage_V', 3.))
+demand = thevenin.Experiment()
+demand.add_step('current_A', 75., (3600., 1.), limits=('voltage_V', 3.))
 
-sol = model.run(experiment)
-sol.plot('capacity_Ah', 'voltage_V')
+soln = model.run(demand)
+soln.plot('time_h', 'voltage_V')
 ```
 
 **Notes:**

--- a/noxfile.py
+++ b/noxfile.py
@@ -22,8 +22,7 @@ def run_flake8(session):
     """
     Run flake8 with the github config file
 
-    Use the optional 'format' argument to run autopep8 on the src and tests
-    directories prior to running the linter.
+    Use the optional 'format' argument to run autopep8 prior to the linter.
 
     """
 
@@ -78,8 +77,8 @@ def run_pytest(session):
     Run pytest and generate test/coverage reports
 
     Use the optional 'parallel' argument to run the tests in parallel. As just
-    a flag, the number of workers will be determined automatically. Otherwise
-    you can specify the number of workers as an int.
+    a flag, the number of workers will be determined automatically. Otherwise,
+    you can specify the number of workers using an int, e.g., parallel=4.
 
     """
 
@@ -122,7 +121,15 @@ def run_genbadge(session):
 
 @nox.session(name='docs', python=False)
 def run_sphinx(session):
-    """Run spellcheck and then use sphinx to build docs"""
+    """
+    Run spellcheck and then use sphinx to build docs
+
+    Use the optional 'clean' argument to remove everything under the 'build'
+    and 'source/api' folders prior to re-building the docs. This is important
+    in cases where the api module names have been changed or when some navbars
+    are not showing new pages. In general, try without 'clean' first.
+
+    """
 
     if 'clean' in session.posargs:
         os.chdir('sphinx')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
     "nox",
     "pytest",
     "pytest-cov",
+    "pytest-xdist",
     "genbadge[all]",
     "codespell",
     "flake8",
@@ -53,3 +54,9 @@ dev = [
     "myst-nb",
     "pydata-sphinx-theme",
 ]
+
+[project.urls]
+Homepage = "https://github.com/ROVI-org/thevenin"
+Documentation = "https://rovi-org.github.io/thevenin/"
+Repository = "https://github.com/ROVI-org/thevenin"
+Issues = "https://github.com/ROVI-org/thevenin/issues"

--- a/src/thevenin/_ida_solver.py
+++ b/src/thevenin/_ida_solver.py
@@ -8,9 +8,6 @@ from scikits_odes_sundials import ida
 class SolverReturn:
     """Solver return."""
 
-    __slots__ = ('_success', '_message', '_t', '_y', '_ydot', '_roots',
-                 '_tstop', '_errors',)
-
     def __init__(self, solution: ida.SolverReturn) -> None:
         """
         A class to wrap the returned arrays and status of the IDASolver.

--- a/src/thevenin/_model.py
+++ b/src/thevenin/_model.py
@@ -316,7 +316,7 @@ class Model:
 
         Returns
         -------
-        sol : StepSolution
+        soln : StepSolution
             Solution to the experiment step.
 
         Warning
@@ -362,16 +362,16 @@ class Model:
         solver = IDASolver(self._residuals, **kwargs)
 
         start = time.time()
-        idasol = solver.solve(step['tspan'], self._sv0, self._svdot0)
+        ida_soln = solver.solve(step['tspan'], self._sv0, self._svdot0)
         timer = time.time() - start
 
-        sol = StepSolution(self, idasol, timer)
+        soln = StepSolution(self, ida_soln, timer)
 
-        self._t0 = sol.t[-1]
-        self._sv0 = sol.y[-1]
-        self._svdot0 = sol.ydot[-1]
+        self._t0 = soln.t[-1]
+        self._sv0 = soln.y[-1].copy()
+        self._svdot0 = soln.ydot[-1].copy()
 
-        return sol
+        return soln
 
     def run(self, exp: Experiment) -> CycleSolution:
         """
@@ -384,7 +384,7 @@ class Model:
 
         Returns
         -------
-        sol : CycleSolution
+        soln : CycleSolution
             A stitched solution will all experimental steps.
 
         See also
@@ -399,17 +399,17 @@ class Model:
         sv0 = self._sv0.copy()
         svdot0 = self._svdot0.copy()
 
-        sols = []
+        solns = []
         for i in range(exp.num_steps):
-            sols.append(self.run_step(exp, i))
+            solns.append(self.run_step(exp, i))
 
-        sol = CycleSolution(*sols)
+        soln = CycleSolution(*solns)
 
         self._t0 = 0.
         self._sv0 = sv0
         self._svdot0 = svdot0
 
-        return sol
+        return soln
 
     def _residuals(self, t: float, sv: np.ndarray, svdot: np.ndarray,
                    res: np.ndarray, inputs: dict) -> None:

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -4,85 +4,86 @@ import numpy as np
 
 
 @pytest.fixture(scope='function')
-def exp():
+def demand():
     return thevenin.Experiment()
 
 
-def test_initialization(exp):
+def test_initialization(demand):
 
-    assert exp._steps == []
-    assert exp._kwargs == []
-    assert exp._options == {}
+    assert demand._steps == []
+    assert demand._kwargs == []
+    assert demand._options == {}
 
-    assert exp.steps == []
-    assert exp.num_steps == 0
+    assert demand.steps == []
+    assert demand.num_steps == 0
 
 
-def test_add_step(exp):
+def test_add_step(demand):
 
     # wrong mode
     with pytest.raises(ValueError):
-        exp.add_step('current_C', 1., (3600., 1.))
+        demand.add_step('current_C', 1., (3600., 1.))
 
     # wrong tspan length
     with pytest.raises(ValueError):
-        exp.add_step('current_A', 1., (0., 3600., 150))
+        demand.add_step('current_A', 1., (0., 3600., 150))
 
     # wrong tspan type
     with pytest.raises(TypeError):
-        exp.add_step('current_A', 1., (3600., '1'))
+        demand.add_step('current_A', 1., (3600., '1'))
 
     # bad limits name
     with pytest.raises(ValueError):
-        exp.add_step('current_A', 1., (3600., 1.), limits=('fake', 3.))
+        demand.add_step('current_A', 1., (3600., 1.), limits=('fake', 3.))
 
     # bad limits length
     with pytest.raises(ValueError):
-        exp.add_step('current_A', 1., (3600., 1.),
-                     limits=('voltage_V', 3., 'soc'))
+        demand.add_step('current_A', 1., (3600., 1.),
+                        limits=('voltage_V', 3., 'soc'))
 
     # bad limits value type
     with pytest.raises(TypeError):
-        exp.add_step('current_A', 1., (3600., 1.), limits=('voltage_V', '3'))
+        demand.add_step('current_A', 1., (3600., 1.),
+                        limits=('voltage_V', '3'))
 
     # test current and linspace construction
-    exp.add_step('current_A', 1., (3600., 150))
-    step = exp.steps[0]
+    demand.add_step('current_A', 1., (3600., 150))
+    step = demand.steps[0]
 
-    assert exp.num_steps == 1
+    assert demand.num_steps == 1
     assert np.allclose(step['tspan'], np.linspace(0., 3600., 150))
 
     # test voltage and arange construction
-    exp.add_step('voltage_V', 4., (3600., 1.))
-    step = exp.steps[1]
+    demand.add_step('voltage_V', 4., (3600., 1.))
+    step = demand.steps[1]
 
-    assert exp.num_steps == 2
+    assert demand.num_steps == 2
     assert np.allclose(step['tspan'], np.arange(0., 3601., 1., dtype=float))
 
     # test power construction
-    exp.add_step('power_W', 1., (3600., 1.))
+    demand.add_step('power_W', 1., (3600., 1.))
 
-    assert exp.num_steps == 3
+    assert demand.num_steps == 3
 
     # test limit keyword
-    exp.add_step('current_A', 1., (3600., 1.), limits=('voltage_V', 3.))
+    demand.add_step('current_A', 1., (3600., 1.), limits=('voltage_V', 3.))
 
-    assert exp.steps[-1]['limits'] == ('voltage_V', 3.)
+    assert demand.steps[-1]['limits'] == ('voltage_V', 3.)
 
     # test dynamic load
-    exp.add_step('current_A', lambda t: 1., (3600., 1.))
-    step = exp.steps[-1]
+    demand.add_step('current_A', lambda t: 1., (3600., 1.))
+    step = demand.steps[-1]
 
     assert callable(step['value'])
 
 
-def test_print_steps(exp):
+def test_print_steps(demand):
 
     # no error when empty
-    exp.print_steps()
+    demand.print_steps()
     assert True
 
     # also works with step(s)
-    exp.add_step('current_A', 1., (3600., 1.))
-    exp.print_steps()
+    demand.add_step('current_A', 1., (3600., 1.))
+    demand.print_steps()
     assert True

--- a/tests/test_loadfns.py
+++ b/tests/test_loadfns.py
@@ -5,12 +5,12 @@ import thevenin as thev
 
 def test_ramp():
 
-    load = thev.loadfns.Ramp(5., 10.)
+    demand = thev.loadfns.Ramp(5., 10.)
 
     tp = np.linspace(0, 20, 25)
     yp = 5.*tp + 10.
 
-    assert np.allclose(load(tp), yp)
+    assert np.allclose(demand(tp), yp)
 
 
 def test_ramp_2_constant():
@@ -39,30 +39,30 @@ def test_ramp_2_constant():
         _ = thev.loadfns.Ramp2Constant(6./1e-3, 6., sharpness=-100.)
 
     # positive ramp
-    load = thev.loadfns.Ramp2Constant(6./1e-3, 6.)
+    demand = thev.loadfns.Ramp2Constant(6./1e-3, 6.)
 
     tp = np.linspace(0, 1e-3, 10)
     yp = 6./1e-3*tp + 0.
 
-    assert np.allclose(load(tp), yp)
+    assert np.allclose(demand(tp), yp)
 
     tp = np.linspace(1e-3, 100, 100)
     yp = 6.*np.ones_like(tp)
 
-    assert np.allclose(load(tp), yp)
+    assert np.allclose(demand(tp), yp)
 
     # negative ramp
-    load = thev.loadfns.Ramp2Constant(-6./1e-3, -6.)
+    demand = thev.loadfns.Ramp2Constant(-6./1e-3, -6.)
 
     tp = np.linspace(0, 1e-3, 10)
     yp = -6./1e-3*tp + 0.
 
-    assert np.allclose(load(tp), yp)
+    assert np.allclose(demand(tp), yp)
 
     tp = np.linspace(1e-3, 100, 100)
     yp = -6.*np.ones_like(tp)
 
-    assert np.allclose(load(tp), yp)
+    assert np.allclose(demand(tp), yp)
 
 
 def test_step_function():
@@ -88,17 +88,17 @@ def test_step_function():
     tp = np.array([0, 1, 5])
     yp = np.array([-1, 0, 1])
 
-    load = thev.loadfns.StepFunction(tp, yp, -np.inf)
+    demand = thev.loadfns.StepFunction(tp, yp, -np.inf)
 
     t_test = np.array([-10, 0.5, 4, 10])
     y_test = np.array([-np.inf, -1, 0, 1])
 
-    assert np.isnan(load(np.nan))
-    assert np.allclose(load(t_test), y_test, equal_nan=True)
+    assert np.isnan(demand(np.nan))
+    assert np.allclose(demand(t_test), y_test, equal_nan=True)
 
-    load = thev.loadfns.StepFunction(tp, yp, -np.inf, ignore_nan=True)
+    demand = thev.loadfns.StepFunction(tp, yp, -np.inf, ignore_nan=True)
 
-    assert load(np.nan) == yp[-1]
+    assert demand(np.nan) == yp[-1]
 
 
 def test_ramped_steps():
@@ -130,24 +130,24 @@ def test_ramped_steps():
     tp = np.array([0, 1, 5])
     yp = np.array([-1, 5, 10])
 
-    load = thev.loadfns.RampedSteps(tp, yp, 1e-3)
+    demand = thev.loadfns.RampedSteps(tp, yp, 1e-3)
 
     t_test = np.array([-1, 0.5, 3, 10])
     y_test = np.array([0, -1, 5, 10])
 
-    assert np.allclose(load(t_test), y_test)
+    assert np.allclose(demand(t_test), y_test)
 
     def ramp(t): return 0. + (-1. - 0.) / 1e-3 * t
     t_test = np.linspace(0, 1e-3, 10)
 
-    assert np.allclose(load(t_test), ramp(t_test))
+    assert np.allclose(demand(t_test), ramp(t_test))
 
     def ramp(t): return -1. + (5. - -1.) / 1e-3 * (t - 1.)
     t_test = np.linspace(1, 1 + 1e-3, 10)
 
-    assert np.allclose(load(t_test), ramp(t_test))
+    assert np.allclose(demand(t_test), ramp(t_test))
 
     def ramp(t): return 5. + (10. - 5.) / 1e-3 * (t - 5.)
     t_test = np.linspace(5, 5 + 1e-3, 10)
 
-    assert np.allclose(load(t_test), ramp(t_test))
+    assert np.allclose(demand(t_test), ramp(t_test))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -61,45 +61,45 @@ def model_2RC(dict_params):
 
 
 @pytest.fixture(scope='function')
-def constant_exp():
-    exp = thevenin.Experiment()
-    exp.add_step('current_A', 1., (3600., 1.), limits=('voltage_V', 3.))
-    exp.add_step('current_A', 0., (600., 1.))
-    exp.add_step('current_A', -1., (3600., 1.), limits=('voltage_V', 4.3))
-    exp.add_step('voltage_V', 4.3, (600., 1.))
-    exp.add_step('power_W', 1., (600., 1.), limits=('voltage_V', 3.))
+def constant_demand():
+    demand = thevenin.Experiment()
+    demand.add_step('current_A', 1., (3600., 1.), limits=('voltage_V', 3.))
+    demand.add_step('current_A', 0., (600., 1.))
+    demand.add_step('current_A', -1., (3600., 1.), limits=('voltage_V', 4.3))
+    demand.add_step('voltage_V', 4.3, (600., 1.))
+    demand.add_step('power_W', 1., (600., 1.), limits=('voltage_V', 3.))
 
-    return exp
+    return demand
 
 
 @pytest.fixture(scope='function')
 def dynamic_current():
     def load(t): return np.sin(2.*np.pi*t / 120.)
 
-    exp = thevenin.Experiment()
-    exp.add_step('current_A', load, (600., 1.))
+    demand = thevenin.Experiment()
+    demand.add_step('current_A', load, (600., 1.))
 
-    return exp
+    return demand
 
 
 @pytest.fixture(scope='function')
 def dynamic_voltage():
     def load(t): return 3.8 + 10e-3*np.sin(2.*np.pi*t / 120.)
 
-    exp = thevenin.Experiment()
-    exp.add_step('voltage_V', load, (600., 1.))
+    demand = thevenin.Experiment()
+    demand.add_step('voltage_V', load, (600., 1.))
 
-    return exp
+    return demand
 
 
 @pytest.fixture(scope='function')
 def dynamic_power():
     def load(t): return np.sin(2.*np.pi*t / 120.)
 
-    exp = thevenin.Experiment()
-    exp.add_step('power_W', load, (600., 1.))
+    demand = thevenin.Experiment()
+    demand.add_step('power_W', load, (600., 1.))
 
-    return exp
+    return demand
 
 
 def test_bad_initialization(dict_params):
@@ -114,7 +114,7 @@ def test_bad_initialization(dict_params):
         _ = thevenin.Model(dict_params)
 
 
-def test_model_w_yaml_input(constant_exp, dynamic_current, dynamic_voltage,
+def test_model_w_yaml_input(constant_demand, dynamic_current, dynamic_voltage,
                             dynamic_power):
 
     # using default file
@@ -129,18 +129,18 @@ def test_model_w_yaml_input(constant_exp, dynamic_current, dynamic_voltage,
     with pytest.warns(UserWarning):
         model = thevenin.Model('params.yaml')
 
-    sol = model.run(constant_exp)
-    assert sol.success
-    assert any(sol.roots)
+    soln = model.run(constant_demand)
+    assert soln.success
+    assert any(soln.roots)
 
-    sol = model.run(dynamic_current)
-    assert sol.success
+    soln = model.run(dynamic_current)
+    assert soln.success
 
-    sol = model.run(dynamic_voltage)
-    assert sol.success
+    soln = model.run(dynamic_voltage)
+    assert soln.success
 
-    sol = model.run(dynamic_power)
-    assert sol.success
+    soln = model.run(dynamic_power)
+    assert soln.success
 
 
 def test_bad_yaml_inputs():
@@ -154,14 +154,14 @@ def test_bad_yaml_inputs():
         _ = thevenin.Model('fake')
 
 
-def test_run_step(model_2RC, constant_exp):
+def test_run_step(model_2RC, constant_demand):
 
     sv0 = model_2RC._sv0.copy()
     svdot0 = model_2RC._svdot0.copy()
 
-    stepsol = model_2RC.run_step(constant_exp, 0)
+    stepsoln = model_2RC.run_step(constant_demand, 0)
 
-    assert stepsol.success
+    assert stepsoln.success
     assert not np.allclose(sv0, model_2RC._sv0)
     assert not np.allclose(svdot0, model_2RC._svdot0)
 
@@ -171,115 +171,115 @@ def test_run_step(model_2RC, constant_exp):
     assert np.allclose(svdot0, model_2RC._svdot0)
 
 
-def test_model_w_multistep_exp(model_0RC, model_1RC, model_2RC,
-                               constant_exp):
+def test_model_w_multistep_demand(model_0RC, model_1RC, model_2RC,
+                                  constant_demand):
 
-    sol = model_0RC.run(constant_exp)
-    assert sol.success
-    assert any(sol.roots)
+    soln = model_0RC.run(constant_demand)
+    assert soln.success
+    assert any(soln.roots)
 
-    sol = model_1RC.run(constant_exp)
-    assert sol.success
-    assert any(sol.roots)
+    soln = model_1RC.run(constant_demand)
+    assert soln.success
+    assert any(soln.roots)
 
-    sol = model_2RC.run(constant_exp)
-    assert sol.success
-    assert any(sol.roots)
+    soln = model_2RC.run(constant_demand)
+    assert soln.success
+    assert any(soln.roots)
 
 
 def test_model_w_dynamic_current(model_0RC, model_1RC, model_2RC,
                                  dynamic_current):
 
-    sol = model_0RC.run(dynamic_current)
-    assert sol.success
+    soln = model_0RC.run(dynamic_current)
+    assert soln.success
 
-    sol = model_1RC.run(dynamic_current)
-    assert sol.success
+    soln = model_1RC.run(dynamic_current)
+    assert soln.success
 
-    sol = model_2RC.run(dynamic_current)
-    assert sol.success
+    soln = model_2RC.run(dynamic_current)
+    assert soln.success
 
 
 def test_model_w_dynamic_voltage(model_0RC, model_1RC, model_2RC,
                                  dynamic_voltage):
 
-    sol = model_0RC.run(dynamic_voltage)
-    assert sol.success
+    soln = model_0RC.run(dynamic_voltage)
+    assert soln.success
 
-    sol = model_1RC.run(dynamic_voltage)
-    assert sol.success
+    soln = model_1RC.run(dynamic_voltage)
+    assert soln.success
 
-    sol = model_2RC.run(dynamic_voltage)
-    assert sol.success
+    soln = model_2RC.run(dynamic_voltage)
+    assert soln.success
 
 
 def test_model_w_dynamic_power(model_0RC, model_1RC, model_2RC,
                                dynamic_power):
 
-    sol = model_0RC.run(dynamic_power)
-    assert sol.success
+    soln = model_0RC.run(dynamic_power)
+    assert soln.success
 
-    sol = model_1RC.run(dynamic_power)
-    assert sol.success
+    soln = model_1RC.run(dynamic_power)
+    assert soln.success
 
-    sol = model_2RC.run(dynamic_power)
-    assert sol.success
+    soln = model_2RC.run(dynamic_power)
+    assert soln.success
 
 
 def test_resting_experiment(model_2RC):
 
-    exp = thevenin.Experiment()
-    exp.add_step('current_A', 0., (100., 1.))
+    demand = thevenin.Experiment()
+    demand.add_step('current_A', 0., (100., 1.))
 
-    sol = model_2RC.run(exp)
+    soln = model_2RC.run(demand)
 
-    assert sol.success
-    assert np.allclose(sol.vars['voltage_V'], sol.vars['voltage_V'][0])
+    assert soln.success
+    assert np.allclose(soln.vars['voltage_V'], soln.vars['voltage_V'][0])
 
 
-def test_current_sign_convention(model_2RC, constant_exp):
+def test_current_sign_convention(model_2RC, constant_demand):
 
-    sol = model_2RC.run(constant_exp)
+    soln = model_2RC.run(constant_demand)
 
-    discharge = sol.get_steps(0)
+    discharge = soln.get_steps(0)
     assert all(np.diff(discharge.vars['voltage_V']) < 0.)
 
-    charge = sol.get_steps(2)
+    charge = soln.get_steps(2)
     assert all(np.diff(charge.vars['voltage_V']) > 0.)
 
 
-def test_constant_V_shift_w_constant_R0(model_0RC, constant_exp):
+def test_constant_V_shift_w_constant_R0(model_0RC, constant_demand):
 
     model_0RC.R0 = lambda soc, T_cell: 1e-2
     model_0RC.pre()
 
-    sol = model_0RC.run(constant_exp)
+    soln = model_0RC.run(constant_demand)
 
-    discharge = sol.get_steps(0)
+    discharge = soln.get_steps(0)
     ocv = model_0RC.ocv(discharge.vars['soc'])
     assert np.allclose(ocv - 1e-2, discharge.vars['voltage_V'])
 
-    charge = sol.get_steps(2)
+    charge = soln.get_steps(2)
     ocv = model_0RC.ocv(charge.vars['soc'])
     assert np.allclose(ocv + 1e-2, charge.vars['voltage_V'])
 
 
-def test_isothermal_flag(model_2RC, constant_exp):
+def test_isothermal_flag(model_2RC, constant_demand):
 
     # with heat on
     model_2RC.isothermal = False
     model_2RC.pre()
 
-    sol = model_2RC.run(constant_exp)
-    assert sol.vars['temperature_K'].max() > model_2RC.T_inf
-    assert all(sol.vars['temperature_K'] >= model_2RC.T_inf)
+    soln = model_2RC.run(constant_demand)
+    assert soln.vars['temperature_K'].max() > model_2RC.T_inf
+    assert all(soln.vars['temperature_K'] >= model_2RC.T_inf)
 
     # with heat off
     model_2RC.isothermal = True
     model_2RC.pre()
 
-    sol = model_2RC.run(constant_exp)
-    assert np.allclose(sol.vars['temperature_K'], model_2RC.T_inf)
+    soln = model_2RC.run(constant_demand)
+    assert np.allclose(soln.vars['temperature_K'], model_2RC.T_inf)
 
 
 def test_mutable_warning():

--- a/tests/test_solutions.py
+++ b/tests/test_solutions.py
@@ -7,46 +7,46 @@ import matplotlib.pyplot as plt
 
 
 @pytest.fixture(scope='function')
-def sol():
+def soln():
 
     warnings.filterwarnings('ignore')
 
     model = thevenin.Model()
 
-    exp = thevenin.Experiment()
-    exp.add_step('current_A', 1., (3600., 1.), limits=('voltage_V', 3.))
-    exp.add_step('current_A', 0., (3600., 1.))
+    demand = thevenin.Experiment()
+    demand.add_step('current_A', 1., (3600., 1.), limits=('voltage_V', 3.))
+    demand.add_step('current_A', 0., (3600., 1.))
 
-    sol = model.run(exp)
+    soln = model.run(demand)
 
-    return sol
+    return soln
 
 
-def test_step_and_cycle_solutions(sol):
+def test_step_and_cycle_solutions(soln):
 
     # solvetime works
-    stepsol = sol.get_steps(0)
-    assert stepsol.solvetime
+    step_soln = soln.get_steps(0)
+    assert step_soln.solvetime
 
     # bad plot
     with pytest.raises(KeyError):
-        stepsol.plot('fake', 'plot')
+        step_soln.plot('fake', 'plot')
 
     # plots w/ and w/o units
-    stepsol.plot('soc', 'soc')
-    stepsol.plot('time_h', 'voltage_V')
+    step_soln.plot('soc', 'soc')
+    step_soln.plot('time_h', 'voltage_V')
     plt.close('all')
 
     # solvetime works and times stacked correctly
-    cyclesol = sol.get_steps((0, 1))
-    assert cyclesol.solvetime
-    assert all(np.diff(cyclesol.t) >= 0.)
+    cycle_soln = soln.get_steps((0, 1))
+    assert cycle_soln.solvetime
+    assert all(np.diff(cycle_soln.t) >= 0.)
 
     # bad plot
     with pytest.raises(KeyError):
-        cyclesol.plot('fake', 'plot')
+        cycle_soln.plot('fake', 'plot')
 
     # plots w/ and w/o units
-    cyclesol.plot('soc', 'soc')
-    cyclesol.plot('time_h', 'voltage_V')
+    cycle_soln.plot('soc', 'soc')
+    cycle_soln.plot('time_h', 'voltage_V')
     plt.close('all')


### PR DESCRIPTION
# Description
Minor changes to code to rename "exp" experiment instances to demand to avoid confusion with exponentials. Also fixed example in README, which had a typo, wanted a 1C discharge, not C/10.

## Type of change
Please add a line in the relevant section of [CHANGELOG.md](https://github.com/ROVI-org/thevenin/blob/main/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that improves speed/readability/etc.)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Cleanup

# Key checklist:
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`
- [x] Badges are updated: `$ nox -s badges`

The optional `-- format` and `-- write` arguments (see above) attempt to correct formatting issues prior to running the linter, and spelling mistakes prior to running the spellcheck, respectively. You can also run all of the above checks using `$ nox -s pre-commit` instead of running them individually.

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.
