### PR TITLE
Fix tspan bug - issue #10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'windows-latest', 'macos-13', 'macos-latest']
-        python-version: ['3.8', '3.12']
+        python-version: ['3.9', '3.12']
 
     defaults:
       run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # thevenin Changelog
 
-## [Unreleased]()
+## [Version 0.1.1]()
 
 ### New Features
 
 ### Optimizations
+* Add ``options`` to the ``Experiment.print_steps()`` report. This makes it easier to check solver options for each step.
 
 ### Bug Fixes
+* Make the final value of ``tspan`` always match ``t_max``. In cases where ``dt`` is used to construct the time array, the final ``dt`` may differ from the one given. Fixes [Issue #10](https://github.com/ROVI-org/thevenin/issues/10).
 
 ### Breaking Changes
+* Drop support for Python 3.8 which reached end of support as of October 2024.

--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ This package is a wrapper for the well-known Thevenin equivalent circuit model. 
   Figure 1: 2RC Thevenin circuit.
 </p>
 
-This system is governed by the evolution of the state of charge (soc, -), RC overpotentials ($V_j$, V), cell voltage ($V_{\rm cell}$, V), and temperature ($T_{\rm cell}$, K). soc and $V_j$ evolve in time as
+This system is governed by the evolution of the state of charge (SOC, -), RC overpotentials ($V_j$, V), cell voltage ($V_{\rm cell}$, V), and temperature ($T_{\rm cell}$, K). SOC and $V_j$ evolve in time as
 ```math
 \begin{align}
-  &\frac{d\rm soc}{dt} = \frac{-I}{3600 Q_{\rm max}}, \\
+  &\frac{d\rm SOC}{dt} = \frac{-I}{3600 Q_{\rm max}}, \\
   &\frac{dV_j}{dt} = -\frac{V_j}{R_jC_j} + \frac{I}{C_j},
 \end{align}
 ```
-where $I$ is the load current (A), $Q_{\rm max}$ is the maximum nominal cell capacity (Ah), and $R_j$ and $C_j$ are the resistance (Ohm) and capacitance (F) of each RC pair $j$. Note that the sign convention for $I$ is chosen such that positive $I$ discharges the battery (reduces soc) and negative $I$ charges the battery (increases soc). This convention is consistent with common physics-based models, e.g., the single particle model or pseudo-2D model. While not explicitly included in the equations above, $R_j$ and $C_j$ are functions of soc and $T_{\rm cell}$. The temperature increases while the cell is active according to
+where $I$ is the load current (A), $Q_{\rm max}$ is the maximum nominal cell capacity (Ah), and $R_j$ and $C_j$ are the resistance (Ohm) and capacitance (F) of each RC pair $j$. Note that the sign convention for $I$ is chosen such that positive $I$ discharges the battery (reduces SOC) and negative $I$ charges the battery (increases SOC). This convention is consistent with common physics-based models, e.g., the single particle model or pseudo-2D model. While not explicitly included in the equations above, $R_j$ and $C_j$ are functions of SOC and $T_{\rm cell}$. The temperature increases while the cell is active according to
 ```math
 \begin{equation}
   mC_p\frac{dT_{\rm cell}}{dt} = \dot{Q}_{\rm gen} + \dot{Q}_{\rm conv},
@@ -45,22 +45,22 @@ where $I$ is the load current (A), $Q_{\rm max}$ is the maximum nominal cell cap
 where $m$ is mass (kg), $C_p$ is specific heat capacity (J/kg/K), $Q_{\rm gen}$ is the heat generation (W), and $Q_{\rm conv}$ is the convective heat loss (W). Heat generation and convection are defined by
 ```math
 \begin{align}
-  &\dot{Q}_{\rm gen} = I \times (V_{\rm ocv}({\rm soc}) - V_{\rm cell}), \\
+  &\dot{Q}_{\rm gen} = I \times (V_{\rm OCV}({\rm SOC}) - V_{\rm cell}), \\
   &\dot{Q}_{\rm conv} = hA(T_{\infty} - T_{\rm cell}),
 \end{align}
 ```
-where $h$ is the convecitive heat transfer coefficient (W/m<sup>2</sup>/K), $A$ is heat loss area (m<sup>2</sup>), and $T_{\infty}$ is the air/room temperature (K). $V_{\rm ocv}$ is the open circuit voltage (V) and is a function of soc.
+where $h$ is the convecitive heat transfer coefficient (W/m<sup>2</sup>/K), $A$ is heat loss area (m<sup>2</sup>), and $T_{\infty}$ is the air/room temperature (K). $V_{\rm OCV}$ is the open circuit voltage (V) and is a function of SOC.
 
 The overall cell voltage is
 ```math
 \begin{equation}
-  V_{\rm cell} = V_{\rm ocv}({\rm soc}) - \sum_j V_j - IR_0,
+  V_{\rm cell} = V_{\rm OCV}({\rm SOC}) - \sum_j V_j - IR_0,
 \end{equation}
 ```
-where $R_0$ the lone series resistance (Ohm), as shown in Figure 1. Just like the other resistive elements, $R_0$ is a function of soc and $T_{\rm cell}$.
+where $R_0$ the lone series resistance (Ohm), as shown in Figure 1. Just like the other resistive elements, $R_0$ is a function of SOC and $T_{\rm cell}$.
 
 ## Installation
-We recommend using [Anaconda](https://anaconda.com) to install this package due to the [scikits-odes-sundials](https://scikits-odes.readthedocs.io) dependency, which is installed separately using `conda install` to avoid having to download and compile SUNDIALS using a local C compiler and a signicant number of C source files. Please refer to the linked `scikits-odes` documentation if you'd prefer to install their package without using `conda`.
+We recommend using [Anaconda](https://anaconda.com) to install this package due to the [scikits-odes-sundials](https://scikits-odes.readthedocs.io) dependency, which is installed separately using `conda install` to avoid having to download and compile SUNDIALS locally. Please refer to the linked `scikits-odes` documentation if you prefer installing without using `conda`. Note that we plan to replace this dependency in a future release to streamline installation.
 
 After cloning the repository, or downloading the files, use your terminal (MacOS/Linux) or Anaconda Prompt (Windows) to navigate into the folder with the `pyproject.toml` file. Once in the correct folder, execute the following commands:
 
@@ -70,7 +70,7 @@ conda activate rovi
 pip install .
 ```
 
-The first command will create a new Python environment named `rovi`. The environment will be set up using Python 3.12 and will install the `scikits-odes-sundials` dependency from the `conda-forge` channel. Feel free to use an alternate environment name as and/or to specify a different Python version >= 3.8. Although the package supports multiple Python versions, development and testing is primarily done using 3.12. Therefore, if you have issues with another version, you should revert to using 3.12. The last two commands activate your new environment and install `thevenin`.
+The first command creates a new Python environment named `rovi`. The environment will be set up using Python 3.12 and will install the `scikits-odes-sundials` dependency from the `conda-forge` channel. Feel free to use an alternate environment name and/or to specify a different Python version >= 3.9. Although the package supports multiple Python versions, development and testing is primarily done using 3.12. Therefore, if you have issues with another version, you should revert to using 3.12. The last two commands activate your new environment and install `thevenin`.
 
 If you plan to make changes to the package, you may also want to consider installing in "editable" mode using the `-e` flag, and including the optional developer dependencies, using `[dev]`, as shown below. If you plan to push any changes back into this repository, you should see the [contributing](#contributing) section first.
 
@@ -86,10 +86,10 @@ import thevenin
 
 model = thevenin.Model()
 
-demand = thevenin.Experiment()
-demand.add_step('current_A', 75., (3600., 1.), limits=('voltage_V', 3.))
+expr = thevenin.Experiment()
+expr.add_step('current_A', 75., (3600., 1.), limits=('voltage_V', 3.))
 
-soln = model.run(demand)
+soln = model.run(expr)
 soln.plot('time_h', 'voltage_V')
 ```
 

--- a/images/tests.svg
+++ b/images/tests.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="62" height="20" role="img" aria-label="tests: 31">
-	<title>tests: 31</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="62" height="20" role="img" aria-label="tests: 32">
+	<title>tests: 32</title>
 	<linearGradient id="s" x2="0" y2="100%">
 		<stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
 		<stop offset="1" stop-opacity=".1"/>
@@ -15,7 +15,7 @@
 	<g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
 		<text aria-hidden="true" x="195.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="270">tests</text>
 		<text x="195.0" y="140" transform="scale(.1)" fill="#fff" textLength="270">tests</text>
-		<text aria-hidden="true" x="485.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="150">31</text>
-		<text x="485.0" y="140" transform="scale(.1)" fill="#fff" textLength="150">31</text>
+		<text aria-hidden="true" x="485.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="150">32</text>
+		<text x="485.0" y="140" transform="scale(.1)" fill="#fff" textLength="150">32</text>
 	</g>
 </svg>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,12 @@ name = "thevenin"
 readme = "README.md"
 dynamic = ["version"]
 description = "Packaged Thevenin equivalent circuit model."
-requires-python = ">=3.8,<3.13"
+requires-python = ">=3.9,<3.13"
 authors = [{name = "Corey R. Randall", email = "corey.randall@nrel.gov"}]
 maintainers = [{name = "Corey R. Randall", email = "corey.randall@nrel.gov"}]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/src/thevenin/__init__.py
+++ b/src/thevenin/__init__.py
@@ -25,7 +25,7 @@ from ._solutions import StepSolution, CycleSolution
 from . import loadfns
 from . import plotutils
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 __all__ = [
     'IDASolver',

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -4,86 +4,106 @@ import numpy as np
 
 
 @pytest.fixture(scope='function')
-def demand():
+def expr():
     return thevenin.Experiment()
 
 
-def test_initialization(demand):
+def test_initialization(expr):
 
-    assert demand._steps == []
-    assert demand._kwargs == []
-    assert demand._options == {}
+    assert expr._steps == []
+    assert expr._kwargs == []
+    assert expr._options == {}
 
-    assert demand.steps == []
-    assert demand.num_steps == 0
+    assert expr.steps == []
+    assert expr.num_steps == 0
 
 
-def test_add_step(demand):
+def test_tspan_construction(expr):
+
+    # Using linspace
+    expr.add_step('current_A', 0., (10., 7))
+
+    step = expr._steps[-1]
+    assert np.allclose(step['tspan'], np.linspace(0., 10., 7))
+
+    # Using arange - evenly divisible
+    expr.add_step('current_A', 0., (10., 2.))
+
+    step = expr._steps[-1]
+    assert np.allclose(step['tspan'], np.array([0., 2., 4., 6., 8., 10.]))
+
+    # Using arange - not evenly divisible
+    expr.add_step('current_A', 0., (10., 3.))
+
+    step = expr._steps[-1]
+    assert np.allclose(step['tspan'], np.array([0., 3., 6., 9., 10.]))
+
+
+def test_add_step(expr):
 
     # wrong mode
     with pytest.raises(ValueError):
-        demand.add_step('current_C', 1., (3600., 1.))
+        expr.add_step('current_C', 1., (3600., 1.))
 
     # wrong tspan length
     with pytest.raises(ValueError):
-        demand.add_step('current_A', 1., (0., 3600., 150))
+        expr.add_step('current_A', 1., (0., 3600., 150))
 
     # wrong tspan type
     with pytest.raises(TypeError):
-        demand.add_step('current_A', 1., (3600., '1'))
+        expr.add_step('current_A', 1., (3600., '1'))
 
     # bad limits name
     with pytest.raises(ValueError):
-        demand.add_step('current_A', 1., (3600., 1.), limits=('fake', 3.))
+        expr.add_step('current_A', 1., (3600., 1.), limits=('fake', 3.))
 
     # bad limits length
     with pytest.raises(ValueError):
-        demand.add_step('current_A', 1., (3600., 1.),
-                        limits=('voltage_V', 3., 'soc'))
+        expr.add_step('current_A', 1., (3600., 1.),
+                      limits=('voltage_V', 3., 'soc'))
 
     # bad limits value type
     with pytest.raises(TypeError):
-        demand.add_step('current_A', 1., (3600., 1.),
-                        limits=('voltage_V', '3'))
+        expr.add_step('current_A', 1., (3600., 1.), limits=('voltage_V', '3'))
 
     # test current and linspace construction
-    demand.add_step('current_A', 1., (3600., 150))
-    step = demand.steps[0]
+    expr.add_step('current_A', 1., (3600., 150))
+    step = expr.steps[0]
 
-    assert demand.num_steps == 1
+    assert expr.num_steps == 1
     assert np.allclose(step['tspan'], np.linspace(0., 3600., 150))
 
     # test voltage and arange construction
-    demand.add_step('voltage_V', 4., (3600., 1.))
-    step = demand.steps[1]
+    expr.add_step('voltage_V', 4., (3600., 1.))
+    step = expr.steps[1]
 
-    assert demand.num_steps == 2
+    assert expr.num_steps == 2
     assert np.allclose(step['tspan'], np.arange(0., 3601., 1., dtype=float))
 
     # test power construction
-    demand.add_step('power_W', 1., (3600., 1.))
+    expr.add_step('power_W', 1., (3600., 1.))
 
-    assert demand.num_steps == 3
+    assert expr.num_steps == 3
 
     # test limit keyword
-    demand.add_step('current_A', 1., (3600., 1.), limits=('voltage_V', 3.))
+    expr.add_step('current_A', 1., (3600., 1.), limits=('voltage_V', 3.))
 
-    assert demand.steps[-1]['limits'] == ('voltage_V', 3.)
+    assert expr.steps[-1]['limits'] == ('voltage_V', 3.)
 
     # test dynamic load
-    demand.add_step('current_A', lambda t: 1., (3600., 1.))
-    step = demand.steps[-1]
+    expr.add_step('current_A', lambda t: 1., (3600., 1.))
+    step = expr.steps[-1]
 
     assert callable(step['value'])
 
 
-def test_print_steps(demand):
+def test_print_steps(expr):
 
     # no error when empty
-    demand.print_steps()
+    expr.print_steps()
     assert True
 
     # also works with step(s)
-    demand.add_step('current_A', 1., (3600., 1.))
-    demand.print_steps()
+    expr.add_step('current_A', 1., (3600., 1.))
+    expr.print_steps()
     assert True

--- a/tests/test_solutions.py
+++ b/tests/test_solutions.py
@@ -13,11 +13,11 @@ def soln():
 
     model = thevenin.Model()
 
-    demand = thevenin.Experiment()
-    demand.add_step('current_A', 1., (3600., 1.), limits=('voltage_V', 3.))
-    demand.add_step('current_A', 0., (3600., 1.))
+    expr = thevenin.Experiment()
+    expr.add_step('current_A', 1., (3600., 1.), limits=('voltage_V', 3.))
+    expr.add_step('current_A', 0., (3600., 1.))
 
-    soln = model.run(demand)
+    soln = model.run(expr)
 
     return soln
 


### PR DESCRIPTION
# Description
Fixes Issue #10 

Makes sure that all time arrays constructed from `Experiment.add_step()` end at `t_max`. A note was added in the docstring because this now means that the final `dt` value may not be consistent with a supplied `(t_max, dt)`.

## Type of change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that improves speed/readability/etc.)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`
- [x] Badges are updated: `$ nox -s badges`

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.
